### PR TITLE
チャット機能のためのモデルとコントローラー実装

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,0 +1,7 @@
+class MessagesController < ApplicationController
+  def index
+  end
+
+  def create
+  end
+end

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,0 +1,2 @@
+module MessagesHelper
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,5 @@
+class Message < ApplicationRecord
+  belongs_to :user
+
+  validates :content, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :messages, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/messages/create.html.erb
+++ b/app/views/messages/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Messages#create</h1>
+<p>Find me in app/views/messages/create.html.erb</p>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Messages#index</h1>
+<p>Find me in app/views/messages/index.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  root "message#index"
   root "home#index"
   devise_for :users
+  resources :message, only: [ :index, :create ]
 end

--- a/db/migrate/20250602220357_create_messages.rb
+++ b/db/migrate/20250602220357_create_messages.rb
@@ -1,0 +1,10 @@
+class CreateMessages < ActiveRecord::Migration[8.0]
+  def change
+    create_table :messages do |t|
+      t.text :content
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_02_204913) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_02_220357) do
+  create_table "messages", force: :cascade do |t|
+    t.text "content"
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_messages_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -22,4 +30,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_02_204913) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "messages", "users"
 end

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class MessagesControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get messages_index_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get messages_create_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  content: MyText
+  user: one
+
+two:
+  content: MyText
+  user: two

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MessageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
■What
チャット機能の土台として、Messageモデルとmessagesコントローラを作成

■Do
・Messageモデル（content, user_id）を作成
・Userモデルに has_many :messages を追加
・messages controllerを indexとcreate アクション付きで作成
・rootを messages#index に設定